### PR TITLE
Add skip of github CI docs on pull request

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -119,7 +119,7 @@ jobs:
       run: terraform plan
 
   documentation:
-    if: ${{ inputs.module_level != 4 }}
+    if: ${{ inputs.module_level != 4 && github.event_name != 'pull_request' }}
     name: Documentation
     needs: [tflint, tfsec, checkov]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Put in a skip of updating docs on the pull request, because merging to main will run it, and the pull request does not have permissions to work.